### PR TITLE
undo/redo fix

### DIFF
--- a/src/Controllers/cli_controller.py
+++ b/src/Controllers/cli_controller.py
@@ -16,6 +16,9 @@ class CLI_Controller:
         r_val = parsed_input[0](*parsed_input[1:])
         if isinstance(r_val, str):
             print(r_val) 
+        # return the Diagram if the function called returns a Diagram
+        if isinstance(r_val, UML_Diagram):
+            return r_val
     
     def request_update(self):
          return prompt("Command: ", completer=self._view._completer).strip()

--- a/src/Controllers/controller.py
+++ b/src/Controllers/controller.py
@@ -25,7 +25,14 @@ class UML_Controller:
         while not self._should_quit:
             try: 
                 data = self.parse(self._controller.request_update())
-                self._controller.update(data)
+                ret = self._controller.update(data)
+                # For now this is only for undo/redo
+                if isinstance(ret, UML_Diagram):
+                    self._diagram = ret
+                # For now this will ensure the state is not saved
+                #     when doing list commands(commands that starts with 'list' prefix)
+                elif not data[0].__name__.startswith('list'):
+                    self._states.save_state(self._diagram)
             except KeyboardInterrupt:
                 self.quit()
             except EOFError:
@@ -33,8 +40,6 @@ class UML_Controller:
             except:
                 self._states.undo(self._diagram)   
                 continue
-            self._states.save_state(self._diagram)
-                
 
     def __pick_controller(self, args:str = sys.argv) -> CLI_Controller | GUI_Controller: 
         if len(args) > 1 and str(args[1]).strip().lower() == 'cli':


### PR DESCRIPTION
Temporarily fix cli undo/redo.
Prevent saving states when command starts with 'list'.