### PR TITLE
Fix moving camera captured as a state for undo/redo

### DIFF
--- a/src/Views/gui_view.py
+++ b/src/Views/gui_view.py
@@ -78,9 +78,10 @@ class GUI_View(tk.Tk):
         self._should_save = False
 
     def on_release(self, event: tk.Event) -> None:
-        self._dragged_class_box = None
+        if self._dragged_class_box:
+            self._dragged_class_box = None
+            self._user_command.set('redraw')
         self._should_save = True
-        self._user_command.set('redraw')
 
     def on_move(self, event: tk.Event) -> None:
         delta_x = event.x - self._cursor_x


### PR DESCRIPTION
Fix moving camera captured as a state for undo/redo